### PR TITLE
Randomly select over auction UId rather than Id

### DIFF
--- a/Controllers/AuctionsController.cs
+++ b/Controllers/AuctionsController.cs
@@ -172,10 +172,10 @@ namespace Coflnet.Sky.Api.Controller
         {
             if (GetTokenHash(token) != "A1D897D3B8DDE4E7119F9624C6A3150E198F0A27279A505B17A1A2DF0C2D7403")
                 throw new CoflnetException("not_allowed", "You are not allowed to access this endpoint, please contact us on discord if you want to use it");
-            var maxId = await context.Auctions.MaxAsync(a => a.Id);
 
-            var randomId = new Random().Next(1, maxId - 100_000);
-            return await context.Auctions.Where(a => a.Id >= randomId && a.HighestBidAmount > 0)
+            // Get a random uid between -minValue and 80% of the +maxValue
+            var randomId = new Random().NextInt64(long.MinValue, (long.MaxValue/5)*4);
+            return await context.Auctions.Where(a => a.UId >= randomId && a.HighestBidAmount > 0)
                 .Take(1)
                 .Include(a => a.Enchantments)
                 .Include(a => a.NbtData)


### PR DESCRIPTION
Randomly selects an auction making use of the [index on the UId field](https://github.com/Coflnet/HypixelSkyblock/blob/8f21e4a55c44447d6d61d6b9c19ce5de429ef8cd/Data/HypixelContext.cs#L79) rather than the primary key. Should still be the same, performance-wise, since it's a [btree index](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/storage-engine-index-types), despite the larger possible range.

Given that the UId column is determined from a [16-digit hex representation of the UUID](https://github.com/Coflnet/HypixelSkyblock/blob/8f21e4a55c44447d6d61d6b9c19ce5de429ef8cd/Server/Services/AuctionService.cs#L38), and parsed as a signed int64, the range of possible values should be fully spread over the minimum to the maximum long values. Decided that 20% of max (10% of the entire space) is a suitable cut-off to ensure that an auction will be returned. Might even be too cautious.

NextInt64 is only available from .NET 6 onwards. This repo uses [.NET 8](https://github.com/Coflnet/SkyAuctions/commit/8a9d823c7f0514b499cb110f3fe417c9786796ba) so that should be fine unless I'm missing something.
<img width="872" height="193" alt="image" src="https://github.com/user-attachments/assets/87bf7cba-1fc7-4117-af5c-d24ccf4bb1a6" />

Note that the HypixelSkyblock repo [only uses .NET 5](https://github.com/Coflnet/HypixelSkyblock/blob/8f21e4a55c44447d6d61d6b9c19ce5de429ef8cd/Dockerfile#L1) so it was worth checking 😅 

This should allow it to uniformly select a valid auction regardless of how many auctions are removed for archival in the near future, making use of the nicely distributed randomness of UUIDs :)