### PR TITLE
Stop PR container builds after tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,18 @@ RUN git clone --depth=1 https://github.com/Ekwav/NotEnoughUpdates-REPO.git NEU-R
 COPY SkyApi.csproj SkyApi.csproj
 RUN dotnet restore
 COPY . .
+
+FROM build AS test
 RUN rm SkyApi.sln && dotnet test
+
+FROM test AS publish
 RUN dotnet publish -c release -o /app /p:UseAppHost=false /p:PublishReadyToRun=true
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-extra
 WORKDIR /app
 
-COPY --from=build --chown=$APP_UID:$APP_UID /app .
-COPY --from=build --chown=$APP_UID:$APP_UID /build/sky/NEU-REPO NEU-REPO
+COPY --from=publish --chown=$APP_UID:$APP_UID /app .
+COPY --from=publish --chown=$APP_UID:$APP_UID /build/sky/NEU-REPO NEU-REPO
 
 ENV ASPNETCORE_URLS=http://+:8000 \
     DOTNET_EnableDiagnostics=0 \


### PR DESCRIPTION
## Summary

- expose the existing `dotnet test` command as the Dockerfile `test` stage
- keep publish and runtime-image construction on merge/main builds
- let the shared Coflnet container workflow stop PR builds at the test stage

The shared workflow change is `Coflnet/.github@9c989e8`. PR runs do not log in
to GHCR, push images, scan/publish them, signal Argo, or run registry cleanup.

## Validation

- `docker buildx build --check .`
- shared workflow validated with actionlint v1.7.7
