### PR TITLE
Fix #291: warden helmet hardened vitality vii overpriced

### DIFF
--- a/Services/Description/ModDescriptionService.Tests.cs
+++ b/Services/Description/ModDescriptionService.Tests.cs
@@ -253,7 +253,7 @@ public class ModDescriptionServiceTests
             .GetCostFromDungeonChest(auctions.Select(a => (a.auction, a.desc)).ToList()).Should().Be(1_000_000);
     }
 
-    [TestCase("DRILL", 5_000_000)]
+    [TestCase("DRILL", 4_900_000)]
     [TestCase("PROMISING_PICKAXE", 0)]
     public void IgnoresEnchantOnPromising(string tag, int price)
     {
@@ -264,6 +264,25 @@ public class ModDescriptionServiceTests
             }}
         });
         enchantVal.Sum(e => e.Item2).Should().Be(price);
+    }
+
+    [Test]
+    public void GetEnchantBreakdown_UsesSelectedBazaarPriceMode()
+    {
+        var auction = new SaveAuction
+        {
+            Tag = "DRILL",
+            Enchantments = [new Enchantment(Enchantment.EnchantmentType.efficiency, 6)]
+        };
+        var bazaarPrices = new Dictionary<string, ItemPrice>
+        {
+            ["SIL_EX"] = new() { BuyPrice = 300_000_000, SellPrice = 500_000 }
+        };
+
+        service.GetEnchantBreakdown(auction, bazaarPrices, useBuyOrderPrices: false)
+            .Sum(e => e.Item2).Should().Be(500_000);
+        service.GetEnchantBreakdown(auction, bazaarPrices, useBuyOrderPrices: true)
+            .Sum(e => e.Item2).Should().Be(300_000_000);
     }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 

--- a/Services/Description/ModDescriptionService.cs
+++ b/Services/Description/ModDescriptionService.cs
@@ -1507,7 +1507,7 @@ public class ModDescriptionService : IDisposable
     public IEnumerable<(Enchantment e, long)> GetEnchantBreakdown(SaveAuction auction, IDictionary<string, ItemPrice> bazaarPrices, bool useBuyOrderPrices)
     {
         var enchants = auction.Enchantments;
-        var lookup = bazaarPrices.ToDictionary(a => a.Key, a => useBuyOrderPrices ? a.Value.BuyPrice : a.Value.BuyPrice);
+        var lookup = bazaarPrices.ToDictionary(a => a.Key, a => useBuyOrderPrices ? a.Value.BuyPrice : a.Value.SellPrice);
         var relevant = mapper.IrrelevantOn(auction.Tag).ToDictionary(a => a.Item1, a => a.level);
         var enchantValues = enchants.Where(e => !relevant.TryGetValue(e.Type, out var l) || l < e.Level)
                     .Select(e => (e, mapper.EnchantValue(e, auction.FlatenedNBT, lookup, auction.Tag)));


### PR DESCRIPTION
Automated patch for #291 from task `task_h4tcfzwckcjl4qcfvsmq`.

Base branch: `main`
Base commit: `587d1672fca86a97e14b2f6421407828c2224cec`

Review: separate codex session recorded.

> WARNING: review uses a separate session of the same provider; it is not an independent-provider review

Tests:
- [x] `container_build` — sha256:2203e30e89e09a7977769c9e0717cc47229662ed8d0ad32a080388a1d2e5fa34
- [x] `regression_base_fail_patch_pass` — trusted-harness exact command, isolated checkout servers, and reviewed test overlays: overlay_derivation=applied:1 sibling_setup_exit=0 overlay_setup_exit=0 overlay_review_digest=unavailable overlay_receipt_sha256=unavailable base_setup_exit=0 base_setup_log_sha256=unavailable server_isolation_exit=0 base_exit=1 base_log_sha256=3f5bf9a8183f9bff134806dc0044a5affe6e3951b2e94ad0df66d6cbae467c04 patched_exit=0 patched_log_sha256=f45c9c91712a168897e33c50794841ab219eab454fe70b462a221c277426a3cd

---

Kept the focused issue #291 valuation fix unchanged. No premium or authentication work was added; that review guidance was stale from issue #277.

Focused Docker test stage passes all 176 tests. The next reviewer should evaluate the 300M-versus-500K enchant valuation regression only.

This PR cannot be merged or approved by the automation identity; human review is required.
